### PR TITLE
Auth modes of RFC9180 and limitations of KEMs

### DIFF
--- a/draft-ietf-hpke-pq.md
+++ b/draft-ietf-hpke-pq.md
@@ -340,7 +340,7 @@ additional functions `AuthEncap` and `AuthDecap`. These functions allowed
 a sender to authenticate the message to the recipient without interaction.
 
 The KEMs defined in this document do not support `AuthEncap`/`AuthDecap` and
-can not be used to migrate uses of HPKE that rely on this mode.
+cannot be used to migrate uses of HPKE that rely on this mode.
 Pre-shared-key-authenticated HPKE ({{!I-D.ietf-hpke-hpke}}, Section 5.1.2)
 or (post-quantum) digital signatures may be suitable alternatives.
 

--- a/draft-ietf-hpke-pq.md
+++ b/draft-ietf-hpke-pq.md
@@ -341,8 +341,8 @@ a sender to authenticate the message to the recipient without interaction.
 
 The KEMs defined in this document do not support `AuthEncap`/`AuthDecap` and
 cannot be used to migrate uses of HPKE that rely on this mode.
-Pre-shared-key-authenticated HPKE ({{!I-D.ietf-hpke-hpke}}, Section 5.1.2)
-or (post-quantum) digital signatures may be suitable alternatives.
+PSK-authenticated HPKE ({{Section 5.1.2 of HPKE}})
+or digital signatures may be suitable alternatives.
 
 # IANA Considerations
 

--- a/draft-ietf-hpke-pq.md
+++ b/draft-ietf-hpke-pq.md
@@ -333,6 +333,17 @@ including both implementation flaws as well as new cryptanalysis. See
 {{?I-D.irtf-cfrg-hybrid-kems}} for further analysis of hybrid security
 properties.
 
+## Asymmetric-key-authenticated modes of RFC9180
+
+In the {{?RFC9180}} version of HPKE, KEMs could optionally define the
+additional functions `AuthEncap` and `AuthDecap`. These functions allowed
+a sender to authenticate the message to the recipient without interaction.
+
+The KEMs defined in this document do not support `AuthEncap`/`AuthDecap` and
+can not be used to migrate uses of HPKE that rely on this mode.
+Pre-shared-key-authenticated HPKE ({{!I-D.ietf-hpke-hpke}}, Section 5.1.2)
+or (post-quantum) digital signatures may be suitable alternatives.
+
 # IANA Considerations
 
 This section requests that IANA perform three actions:

--- a/draft-ietf-hpke-pq.md
+++ b/draft-ietf-hpke-pq.md
@@ -341,7 +341,7 @@ a sender to authenticate the message to the recipient without interaction.
 
 The KEMs defined in this document do not support `AuthEncap`/`AuthDecap` and
 cannot be used to migrate uses of HPKE that rely on this mode.
-PSK-authenticated HPKE ({{Section 5.1.2 of HPKE}})
+PSK-authenticated HPKE ({{Section 5.1.2 of I-D.barnes-hpke-hpke}})
 or digital signatures may be suitable alternatives.
 
 # IANA Considerations

--- a/draft-ietf-hpke-pq.md
+++ b/draft-ietf-hpke-pq.md
@@ -341,7 +341,7 @@ a sender to authenticate the message to the recipient without interaction.
 
 The KEMs defined in this document do not support `AuthEncap`/`AuthDecap` and
 cannot be used to migrate uses of HPKE that rely on this mode.
-PSK-authenticated HPKE ({{Section 5.1.2 of I-D.barnes-hpke-hpke}})
+PSK-authenticated HPKE ({{Section 5.1.2 of I-D.ietf-hpke-hpke}})
 or digital signatures may be suitable alternatives.
 
 # IANA Considerations


### PR DESCRIPTION
Security considerations seemed to make sense, but this section could also go into the introduction.

I did not get too technical ("DH is a NIKE, KEMs are not NIKE"), but if we want that is an option.

If there's a better way to link to a paragraph in another draft, that'd be a great improvement over my hard-coded section number.